### PR TITLE
Fix an exception (TypeError) in function getStereoscopeMode() on startup

### DIFF
--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -49,14 +49,14 @@ def intToCompString(comp):
     }
     return switch.get(comp, "NOT_FOUND")
 
-def modeTo3D(self, mode):
+def modeTo3D(mode=None):
     switch = {
         "split_vertical": "3DSBS",
         "split_horizontal": "3DTAB",
     }
     return switch.get(mode, "2D")
 
-def getStereoscopeMode(self):
+def getStereoscopeMode():
     try:
         response = json.loads(xbmc.executeJSONRPC('{"jsonrpc":"2.0","method":"GUI.GetProperties","params":{"properties":["stereoscopicmode"]},"id":669}'))
         mode = response["result"]["stereoscopicmode"]["mode"]


### PR DESCRIPTION
`2019-11-28 11:01:08.332 T:140554339870464   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.TypeError'>
                                            Error Contents: getStereoscopeMode() takes exactly 1 argument (0 given)
                                            Traceback (most recent call last):
                                              File "/storage/.kodi/addons/hyperion.control/service.py", line 221, in <module>
                                                hyperion = Hyperion()
                                              File "/storage/.kodi/addons/hyperion.control/service.py", line 91, in __init__
                                                self.updateSettings()
                                              File "/storage/.kodi/addons/hyperion.control/service.py", line 165, in updateSettings
                                                self.updateState()
                                              File "/storage/.kodi/addons/hyperion.control/service.py", line 215, in updateState
                                                newMode = getStereoscopeMode()
                                            TypeError: getStereoscopeMode() takes exactly 1 argument (0 given)
                                            -->End of Python script error report<--
`