### PR TITLE
build: create release zip

### DIFF
--- a/.github/workflows/publish-addon.yml
+++ b/.github/workflows/publish-addon.yml
@@ -38,8 +38,12 @@ jobs:
         pip install -q git+https://github.com/xbmc/kodi-addon-submitter.git
     - name: Submit addon
       run: |
-        submit-addon -r repo-scripts -b $TARGET_KODI_VER -s --pull-request $ADDON_NAME
+        submit-addon -r repo-scripts -b $TARGET_KODI_VER -s -z --pull-request $ADDON_NAME
       env:
         GH_USERNAME: ${{ github.actor }}
         GH_TOKEN: ${{ secrets.GH_TOKEN }}
         EMAIL: "${{ github.actor }}@users.noreply.github.com"
+    - name: Publish release
+      uses: ncipollo/release-action@v1
+      with:
+        artifacts: "${ADDON_NAME}-*.zip"

--- a/.github/workflows/publish-addon.yml
+++ b/.github/workflows/publish-addon.yml
@@ -22,7 +22,31 @@ jobs:
       run: |
         kodi-addon-checker --branch $TARGET_KODI_VER --allow-folder-id-mismatch $ADDON_NAME
 
-  publish:
+  github_release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    needs: check
+    if: github.ref_type == 'tag'
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.11"
+    - name: Install addon submitter
+      run: |
+        pip install -q git+https://github.com/xbmc/kodi-addon-submitter.git
+    - name: Package addon
+      run: |
+        submit-addon -s -z $ADDON_NAME
+    - name: Publish release
+      uses: ncipollo/release-action@v1
+      with:
+        artifacts: "*.zip"
+
+  kodi_publish:
     runs-on: ubuntu-latest
 
     needs: check
@@ -38,12 +62,8 @@ jobs:
         pip install -q git+https://github.com/xbmc/kodi-addon-submitter.git
     - name: Submit addon
       run: |
-        submit-addon -r repo-scripts -b $TARGET_KODI_VER -s -z --pull-request $ADDON_NAME
+        submit-addon -r repo-scripts -b $TARGET_KODI_VER -s --pull-request $ADDON_NAME
       env:
         GH_USERNAME: ${{ github.actor }}
         GH_TOKEN: ${{ secrets.GH_TOKEN }}
         EMAIL: "${{ github.actor }}@users.noreply.github.com"
-    - name: Publish release
-      uses: ncipollo/release-action@v1
-      with:
-        artifacts: "${ADDON_NAME}-*.zip"


### PR DESCRIPTION
Hi, this should solve the problem with the release zip file.
It should also automatically create a release when you push a tag.
I didn't test it because I don't really know how to do it locally!
